### PR TITLE
Do not fail, if the caller didn't pick up response from previous call

### DIFF
--- a/src/card_7816.c
+++ b/src/card_7816.c
@@ -732,11 +732,9 @@ vcard_process_apdu(VCard *card, VCardAPDU *apdu, VCardResponse **response)
     }
     buffer_response = vcard_get_buffer_response(card);
     if (buffer_response && apdu->a_ins != VCARD7816_INS_GET_RESPONSE) {
-        /* clear out buffer_response, return an error */
+        /* clear out buffer_response, do not return an error */
         vcard_set_buffer_response(card, NULL);
         vcard_buffer_response_delete(buffer_response);
-        *response = vcard_make_response(VCARD7816_STATUS_EXC_ERROR);
-        return VCARD_DONE;
     }
 
     status = vcard_process_applet_apdu(card, apdu, response);


### PR DESCRIPTION
During our testing of a new CAC driver in OpenSC, with this library, we encountered a problem with `libcacard` failing and the driver returning only a fraction of the requested objects.

The problem is that the Emulator wants to return the data (properly signalized by 61 (RESPONSE BYTES) in SW1), but this is ignored for some reason in some calls. The Emulator should not fail hard with the next independent request, rather silently drop the buffer and serve the ongoing APDU request (I would left for consideration to somehow log such problem).

Patch was successfully tested on Fedora 24 host and solves our problem (though we worked around the problem already in the driver too).